### PR TITLE
Change filepaths strings to url to ensure OS cross compatibility

### DIFF
--- a/packages/server-core/src/serverTypes.ts
+++ b/packages/server-core/src/serverTypes.ts
@@ -33,12 +33,12 @@ export interface TableProps {
 }
 
 export interface TableWithGenerators {
-  createPath?: string;
-  updatePath?: string;
+  createPath?: URL;
+  updatePath?: URL;
 }
 
 export interface TableConfig extends TableProps, TableWithGenerators {
-  dataPath: string;
+  dataPath: URL;
 }
 
 export interface ServerConfig {

--- a/packages/viewserver/dataTables/instrumentPrices/index.ts
+++ b/packages/viewserver/dataTables/instrumentPrices/index.ts
@@ -1,5 +1,7 @@
 import path from 'path';
 import fs from 'fs';
+import { pathToFileURL } from 'url';
+import { TableConfig } from 'packages/server-core/src';
 
 const path_root = 'node_modules/@heswell/viewserver/dist/dataTables';
 
@@ -7,7 +9,7 @@ const project_path = path.resolve(fs.realpathSync('.'), `${path_root}/instrument
 
 const config = {
   name: 'InstrumentPrices',
-  dataPath: `${project_path}/data-generator.js`,
+  dataPath: pathToFileURL(`${project_path}/data-generator.js`),
   type: 'vs',
   primaryKey: 'ric',
   columns: [

--- a/packages/viewserver/dataTables/instruments/index.ts
+++ b/packages/viewserver/dataTables/instruments/index.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import { pathToFileURL } from 'url';
 
 const path_root = 'node_modules/@heswell/viewserver/dist/dataTables';
 
@@ -7,7 +8,7 @@ const project_path = path.resolve(fs.realpathSync('.'), `${path_root}/instrument
 
 const config = {
   name: 'instruments',
-  dataPath: `${project_path}/data-generator.js`,
+  dataPath: pathToFileURL(`${project_path}/data-generator.js`),
   type: 'vs',
   primaryKey: 'ric',
   columns: [

--- a/packages/viewserver/dataTables/order-blotter/index.ts
+++ b/packages/viewserver/dataTables/order-blotter/index.ts
@@ -1,13 +1,14 @@
 import path from 'path';
 import fs from 'fs';
+import { pathToFileURL } from 'url';
 
 const path_root = 'node_modules/@heswell/viewserver/dist/dataTables';
 const project_path = path.resolve(fs.realpathSync('.'), `${path_root}/order-blotter`);
 
 const config = {
   name: 'OrderBlotter',
-  dataPath: `${project_path}/dataset.js`,
-  createPath: `${project_path}/create-row.js`,
+  dataPath: pathToFileURL(`${project_path}/dataset.js`),
+  createPath: pathToFileURL(`${project_path}/create-row.js`),
   // updatePath: `${project_path}/update-row`,
   type: 'vs',
   primaryKey: 'OrderId',

--- a/packages/viewserver/dataTables/order-book/index.ts
+++ b/packages/viewserver/dataTables/order-book/index.ts
@@ -1,13 +1,14 @@
 import fs from 'fs';
+import { pathToFileURL } from 'url';
 
 const data_path = fs.realpathSync(process.cwd());
 const project_path = 'src/@heswell/viewserver/dist/dataTables/order-book';
 
 const config = {
   name: 'order-book',
-  dataPath: `${data_path}/${project_path}/dataset.js`,
-  // createPath: `${data_path}/${project_path}/create-row`,
-  // updatePath: `${data_path}/${project_path}/update-row`,
+  dataPath: pathToFileURL(`${data_path}/${project_path}/dataset.js`),
+  // createPath: pathToFileURL(`${data_path}/${project_path}/create-row`,
+  // updatePath: pathToFileURL(`${data_path}/${project_path}/update-row`,
   type: 'vs',
   primaryKey: 'Id',
   columns: [

--- a/packages/viewserver/dataTables/sets/index.ts
+++ b/packages/viewserver/dataTables/sets/index.ts
@@ -1,13 +1,14 @@
 import fs from 'fs';
+import { pathToFileURL } from 'url';
 
 const data_path = fs.realpathSync(process.cwd());
 const project_path = 'src/@heswell/viewserver/dist/dataTables/sets';
 
 const config = {
   name: 'Sets',
-  dataPath: `${data_path}/${project_path}/dataset.js`,
-  // createPath: `${data_path}/${project_path}/create-row`,
-  // updatePath: `${data_path}/${project_path}/update-row`,
+  dataPath: pathToFileURL(`${data_path}/${project_path}/dataset.js`),
+  // createPath: pathToFileURL(`${data_path}/${project_path}/create-row`,
+  // updatePath: pathToFileURL(`${data_path}/${project_path}/update-row`,
   type: 'vs',
   primaryKey: 'ISIN',
   columns: [

--- a/packages/viewserver/dataTables/simpsons/index.ts
+++ b/packages/viewserver/dataTables/simpsons/index.ts
@@ -1,11 +1,12 @@
 import path from 'path';
 import fs from 'fs';
+import { pathToFileURL } from 'url';
 
 const project_path = path.resolve(fs.realpathSync('.'), 'packages/viewserver/dataTables/simpsons');
 
 const config = {
     name: 'Simpsons',
-    dataPath: `${project_path}/data-generator`,
+    dataPath: pathToFileURL(`file:///${project_path}/data-generator`),
     type: 'vs',
     primaryKey: 'seq',
     columns: [

--- a/packages/viewserver/dataTables/testTable/index.ts
+++ b/packages/viewserver/dataTables/testTable/index.ts
@@ -2,15 +2,16 @@
 // import path from 'path';
 // import url from 'url';
 import fs from 'fs';
+import { pathToFileURL } from 'url';
 
 // const __dirname = path.dirname(new url.URL(import.meta.url).pathname);
 const path = fs.realpathSync(process.cwd());
 
 const config = {
   name: 'TestTable',
-  dataPath: `${path}/data-generator.js`,
-  createPath: `${path}/create-row.js`,
-  updatePath: `${path}/update-row.js`,
+  dataPath: pathToFileURL(`${path}/data-generator.js`),
+  createPath: pathToFileURL(`${path}/create-row.js`),
+  updatePath: pathToFileURL(`${path}/update-row.js`),
   type: 'vs',
   primaryKey: 'Column-1',
   columns: [

--- a/packages/viewserver/src/services/Table.ts
+++ b/packages/viewserver/src/services/Table.ts
@@ -2,7 +2,7 @@ import { Table as BaseTable } from '@heswell/data';
 import { TableWithGenerators } from '@heswell/server-core';
 
 export class Table extends BaseTable {
-  async loadData(dataPath: string) {
+  async loadData(dataPath: URL) {
     try {
       const { data } = await import(`${dataPath}`);
       if (data) {


### PR DESCRIPTION
for dynamic importing of files the filepath requires the protocol of file:// at the beginning. 

In windows when resolving full filepaths, strings starting with "C:/" get returned which aren't compatible 

This PR ensures that any file path get's converted to the required protocol before importing the file irrespective of OS 